### PR TITLE
Fix a minor spelling error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Run:
 run createcomponent AppContainer
 run build:js
 run build:all
-run lint --fix compontets/Button.js
+run lint --fix components/Button.js
 ```
 
 Mechanism of RunJS is very simple. Tasks are run by just importing `runfile.js` as a


### PR DESCRIPTION
The path, 'components', was spelled incorrectly.